### PR TITLE
Delete api keys together with balances, Service: monolith-service

### DIFF
--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/exchanger/ApiKeySetting.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/exchanger/ApiKeySetting.java
@@ -17,10 +17,12 @@ import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Getter
+@EqualsAndHashCode
 @Builder
 @Entity
 @NoArgsConstructor

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/exchanger/ApiKeysPair.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/exchanger/ApiKeysPair.java
@@ -3,12 +3,14 @@ package com.walletsphere.wsmonolith.model.exchanger;
 import jakarta.persistence.Embeddable;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 @Getter
 @Setter
 @Builder

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/requests/RegisterApiKeysReq.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/requests/RegisterApiKeysReq.java
@@ -1,4 +1,6 @@
 package com.walletsphere.wsmonolith.model.requests;
 
-public record RegisterApiKeysReq(String publicKey, String secretKey) {
+import com.walletsphere.wsmonolith.model.enums.ExchangerCode;
+
+public record RegisterApiKeysReq(String publicKey, String secretKey, ExchangerCode code) {
 }

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/requests/RegisterExchangerInfoReq.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/model/requests/RegisterExchangerInfoReq.java
@@ -1,6 +1,4 @@
 package com.walletsphere.wsmonolith.model.requests;
 
-import com.walletsphere.wsmonolith.model.enums.ExchangerCode;
-
-public record RegisterExchangerInfoReq(RegisterApiKeysReq apiKeysReq, ExchangerCode code, String balanceName) {
+public record RegisterExchangerInfoReq(RegisterApiKeysReq apiKeysReq, String balanceName) {
 }

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/apikeys/ApiKeySettingService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/apikeys/ApiKeySettingService.java
@@ -1,9 +1,14 @@
 package com.walletsphere.wsmonolith.services.exchangers.apikeys;
 
+import com.walletsphere.wsmonolith.model.User;
+import com.walletsphere.wsmonolith.model.exchanger.ApiKeySetting;
 import com.walletsphere.wsmonolith.model.exchanger.DecryptedApiKeySettingDTO;
+import com.walletsphere.wsmonolith.model.requests.RegisterApiKeysReq;
 
 import java.util.List;
 
 public interface ApiKeySettingService {
     List<DecryptedApiKeySettingDTO> getDecryptApiKeySettings(long userId);
+
+    ApiKeySetting saveApiKeysSettings(User user, RegisterApiKeysReq apiKeysPair);
 }

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/apikeys/ApiKeySettingService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/apikeys/ApiKeySettingService.java
@@ -2,6 +2,7 @@ package com.walletsphere.wsmonolith.services.exchangers.apikeys;
 
 import com.walletsphere.wsmonolith.model.User;
 import com.walletsphere.wsmonolith.model.exchanger.ApiKeySetting;
+import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.model.exchanger.DecryptedApiKeySettingDTO;
 import com.walletsphere.wsmonolith.model.requests.RegisterApiKeysReq;
 
@@ -10,5 +11,5 @@ import java.util.List;
 public interface ApiKeySettingService {
     List<DecryptedApiKeySettingDTO> getDecryptApiKeySettings(long userId);
 
-    ApiKeySetting saveApiKeysSettings(User user, RegisterApiKeysReq apiKeysPair);
+    ApiKeySetting saveApiKeysSettings(User user, Balance balance, RegisterApiKeysReq apiKeysPair);
 }

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/apikeys/ApiKeySettingServiceImpl.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/apikeys/ApiKeySettingServiceImpl.java
@@ -4,6 +4,7 @@ import com.walletsphere.wsmonolith.model.User;
 import com.walletsphere.wsmonolith.model.enums.ExchangerCode;
 import com.walletsphere.wsmonolith.model.exchanger.ApiKeySetting;
 import com.walletsphere.wsmonolith.model.exchanger.ApiKeysPair;
+import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.model.exchanger.DecryptedApiKeySettingDTO;
 import com.walletsphere.wsmonolith.model.requests.RegisterApiKeysReq;
 import com.walletsphere.wsmonolith.repositories.ApiKeySettingRepository;
@@ -33,13 +34,15 @@ public class ApiKeySettingServiceImpl implements ApiKeySettingService {
     }
 
     @Override
-    public ApiKeySetting saveApiKeysSettings(User user, RegisterApiKeysReq apiKeysPair) {
+    public ApiKeySetting saveApiKeysSettings(User user, Balance balance, RegisterApiKeysReq apiKeysPair) {
         ApiKeySetting apiKeySetting = ApiKeySetting.builder()
                 .user(user)
                 .code(apiKeysPair.code())
                 .apiKeys(buildEncryptedApiKeysPair(apiKeysPair))
+                .balance(balance)
                 .build();
 
+        balance.setApiKeySetting(apiKeySetting);
         user.getApiKeysSettings().add(apiKeySetting);
 
         return apiKeySettingRepository.save(apiKeySetting);

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/BalanceService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/BalanceService.java
@@ -1,15 +1,15 @@
 package com.walletsphere.wsmonolith.services.exchangers.balances;
 
-import com.walletsphere.wsmonolith.model.User;
 import com.walletsphere.wsmonolith.model.enums.ExchangerCode;
 import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.model.exchanger.ExchangerUniqueCurrenciesDTO;
+import com.walletsphere.wsmonolith.model.requests.RegisterExchangerInfoReq;
 
 import java.util.List;
 
 public interface BalanceService {
 
-    Balance registerBalanceEntryInfo(ExchangerCode code, String balanceName, User user);
+    Balance registerBalanceEntryInfo(RegisterExchangerInfoReq exchangerInfoReq, Long userId);
     List<Balance> getMainBalances(long userId);
     Balance getMainBalance(long userId, ExchangerCode exchangerCode);
     void deleteBalance(long balanceId);

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/CommonBalanceService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/CommonBalanceService.java
@@ -6,10 +6,12 @@ import com.walletsphere.wsmonolith.model.enums.ExchangerCode;
 import com.walletsphere.wsmonolith.model.exchanger.ApiKeySetting;
 import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.model.exchanger.ExchangerUniqueCurrenciesDTO;
+import com.walletsphere.wsmonolith.model.requests.RegisterExchangerInfoReq;
 import com.walletsphere.wsmonolith.repositories.BalanceRepository;
 import com.walletsphere.wsmonolith.services.UserService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorServiceFactory;
+import com.walletsphere.wsmonolith.services.exchangers.apikeys.ApiKeySettingService;
 import com.walletsphere.wsmonolith.services.exchangers.balances.cache.BalanceCacheHandler;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.CachePut;
@@ -29,27 +31,33 @@ public abstract class CommonBalanceService implements BalanceService {
     private final UserService userService;
     private final Map<ExchangerCode, ExchangerConnectorServiceFactory> exchangerServiceFactories;
     private final BalanceCacheHandler balanceCacheHandler;
+   private final ApiKeySettingService apiKeySettingService;
 
 
     public CommonBalanceService(BalanceRepository balanceRepository, UserService userService,
                                 List<ExchangerConnectorServiceFactory> exchangerServiceFactories,
-                                BalanceCacheHandler balanceCacheHandler) {
+                                BalanceCacheHandler balanceCacheHandler, ApiKeySettingService apiKeySettingService) {
             this.balanceRepository = balanceRepository;
             this.userService = userService;
             this.exchangerServiceFactories = exchangerServiceFactories.stream()
                     .collect(Collectors.toMap(ExchangerConnectorServiceFactory::getExchangerCode, factory -> factory));
             this.balanceCacheHandler = balanceCacheHandler;
+            this.apiKeySettingService = apiKeySettingService;
         }
 
     // No need to put in cache, because it will be synchronised first, and it will be saved in cache at that stage
     @Override
-    public Balance registerBalanceEntryInfo(ExchangerCode code, String balanceName, User user) {
+    @Transactional
+    public Balance registerBalanceEntryInfo(RegisterExchangerInfoReq exchangerInfoReq, Long userId) {
+        User user = userService.getUserById(userId);
+
         Balance emptyBalance = Balance.builder()
-                .code(code)
-                .balanceName(balanceName)
+                .code(exchangerInfoReq.apiKeysReq().code())
+                .balanceName(exchangerInfoReq.balanceName())
                 .user(user)
                 .build();
 
+        apiKeySettingService.saveApiKeysSettings(user, exchangerInfoReq.apiKeysReq());
         return balanceRepository.save(emptyBalance);
     }
 

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/CommonBalanceService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/CommonBalanceService.java
@@ -57,7 +57,7 @@ public abstract class CommonBalanceService implements BalanceService {
                 .user(user)
                 .build();
 
-        apiKeySettingService.saveApiKeysSettings(user, exchangerInfoReq.apiKeysReq());
+        apiKeySettingService.saveApiKeysSettings(user, emptyBalance, exchangerInfoReq.apiKeysReq());
         return balanceRepository.save(emptyBalance);
     }
 

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/LocalBalanceService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/LocalBalanceService.java
@@ -5,6 +5,7 @@ import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.repositories.BalanceRepository;
 import com.walletsphere.wsmonolith.services.UserService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorServiceFactory;
+import com.walletsphere.wsmonolith.services.exchangers.apikeys.ApiKeySettingService;
 import com.walletsphere.wsmonolith.services.exchangers.balances.cache.BalanceCacheHandler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cache.annotation.Cacheable;
@@ -20,8 +21,8 @@ public class LocalBalanceService extends CommonBalanceService {
 
     public LocalBalanceService(BalanceRepository balanceRepository, UserService userService,
                                List<ExchangerConnectorServiceFactory> exchangerServiceFactories,
-                               BalanceCacheHandler balanceCacheHandler) {
-        super(balanceRepository, userService, exchangerServiceFactories, balanceCacheHandler);
+                               BalanceCacheHandler balanceCacheHandler, ApiKeySettingService apiKeySettingService) {
+        super(balanceRepository, userService, exchangerServiceFactories, balanceCacheHandler, apiKeySettingService);
         this.balanceRepository = balanceRepository;
     }
 

--- a/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/RemoteBalanceService.java
+++ b/service/monolith-part/src/main/java/com/walletsphere/wsmonolith/services/exchangers/balances/RemoteBalanceService.java
@@ -6,6 +6,7 @@ import com.walletsphere.wsmonolith.repositories.BalanceRepository;
 import com.walletsphere.wsmonolith.services.UserService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorServiceFactory;
+import com.walletsphere.wsmonolith.services.exchangers.apikeys.ApiKeySettingService;
 import com.walletsphere.wsmonolith.services.exchangers.balances.cache.BalanceCacheHandler;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
@@ -18,8 +19,9 @@ public class RemoteBalanceService extends CommonBalanceService {
 
     public RemoteBalanceService(BalanceRepository balanceRepository,
                                 List<ExchangerConnectorServiceFactory> exchangerServiceFactories,
-                                UserService userService, BalanceCacheHandler balanceCacheHandler) {
-        super(balanceRepository, userService, exchangerServiceFactories, balanceCacheHandler);
+                                UserService userService, BalanceCacheHandler balanceCacheHandler,
+                                ApiKeySettingService apiKeySettingService) {
+        super(balanceRepository, userService, exchangerServiceFactories, balanceCacheHandler, apiKeySettingService);
     }
 
     @Override

--- a/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/repositories/custom/impl/ApiKeySettingServiceImplTest.java
+++ b/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/repositories/custom/impl/ApiKeySettingServiceImplTest.java
@@ -4,6 +4,7 @@ import static com.walletsphere.wsmonolith.model.enums.ExchangerCode.WHITE_BIT;
 import com.walletsphere.wsmonolith.model.User;
 import com.walletsphere.wsmonolith.model.exchanger.ApiKeySetting;
 import com.walletsphere.wsmonolith.model.exchanger.ApiKeysPair;
+import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.model.exchanger.DecryptedApiKeySettingDTO;
 import com.walletsphere.wsmonolith.model.requests.RegisterApiKeysReq;
 import com.walletsphere.wsmonolith.repositories.ApiKeySettingRepository;
@@ -27,6 +28,7 @@ import java.util.List;
 class ApiKeySettingServiceImplTest {
 
     private static final long USER_ID = 1L;
+    private static final long BALANCE_ID = 2L;
     private static final String ENCRYPTED_PUB_KEY = "encryptedPubKey";
     private static final String DECRYPTED_PUB_KEY = "decryptedPubKey";
     private static final String ENCRYPTED_PRI_KEY = "encryptedPriKey";
@@ -40,12 +42,12 @@ class ApiKeySettingServiceImplTest {
     private ApiKeySettingService apiKeySettingService;
 
     private User testUser;
+    private Balance testBalance;
 
     @BeforeEach
     void setUp() {
-        testUser = User.builder()
-                .id(USER_ID)
-                .build();
+        testUser = User.builder().id(USER_ID).build();
+        testBalance = Balance.builder().id(BALANCE_ID).build();
         apiKeySettingService = new ApiKeySettingServiceImpl(apiKeySettingRepository, aesEncryptionService);
     }
 
@@ -83,12 +85,13 @@ class ApiKeySettingServiceImplTest {
         ApiKeySetting encryptedApiKeySetting = ApiKeySetting.builder()
                 .user(testUser)
                 .code(WHITE_BIT)
+                .balance(testBalance)
                 .apiKeys(encryptedApiKeysPair)
                 .build();
 
         RegisterApiKeysReq registerApiKeysReq = new RegisterApiKeysReq(DECRYPTED_PUB_KEY, DECRYPTED_PRI_KEY, WHITE_BIT);
 
-        ApiKeySetting expected = new ApiKeySetting(1L, testUser, null, WHITE_BIT, encryptedApiKeysPair);
+        ApiKeySetting expected = new ApiKeySetting(1L, testUser, testBalance, WHITE_BIT, encryptedApiKeysPair);
 
         when(apiKeySettingRepository.save(eq(encryptedApiKeySetting))).thenReturn(expected);
         when(aesEncryptionService.encrypt(eq(DECRYPTED_PUB_KEY))).thenReturn(ENCRYPTED_PUB_KEY);
@@ -96,7 +99,7 @@ class ApiKeySettingServiceImplTest {
 
 
         // when
-        ApiKeySetting result = apiKeySettingService.saveApiKeysSettings(testUser, registerApiKeysReq);
+        ApiKeySetting result = apiKeySettingService.saveApiKeysSettings(testUser, testBalance, registerApiKeysReq);
 
         // then
 
@@ -104,5 +107,6 @@ class ApiKeySettingServiceImplTest {
         assertThat(result.getApiKeys()).isEqualTo(encryptedApiKeysPair);
         assertThat(result.getCode()).isEqualTo(WHITE_BIT);
         assertThat(result.getUser()).isEqualTo(testUser);
+        assertThat(result.getBalance().getId()).isEqualTo(BALANCE_ID);
     }
 }

--- a/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/services/exchangers/balances/CommonBalanceServiceTest.java
+++ b/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/services/exchangers/balances/CommonBalanceServiceTest.java
@@ -69,23 +69,20 @@ class CommonBalanceServiceTest {
         // given
         ExchangerCode code = ExchangerCode.WHITE_BIT;
 
-        Balance expectedBalance = Balance.builder()
-                        .code(code)
-                        .balanceName(BALANCE_NAME)
-                        .user(testUser)
-                        .build();
+        Balance balance = Balance.builder().code(code).balanceName(BALANCE_NAME).user(testUser).build();
+        Balance expectedBalance = Balance.builder().id(BALANCE_ID).code(code).balanceName(BALANCE_NAME).user(testUser).build();
 
         RegisterApiKeysReq apiKeysReq = new RegisterApiKeysReq("pubKey", "secKey", code);
         RegisterExchangerInfoReq infoReq = new RegisterExchangerInfoReq(apiKeysReq, BALANCE_NAME);
 
-        when(balanceRepository.save(eq(expectedBalance))).thenReturn(expectedBalance.toBuilder().id(BALANCE_ID).build());
+        when(balanceRepository.save(eq(balance))).thenReturn(expectedBalance);
         when(userService.getUserById(eq(USER_ID))).thenReturn(testUser);
 
         // when
         Balance result = commonBalanceService.registerBalanceEntryInfo(infoReq, USER_ID);
 
         // then
-        verify(apiKeySettingService).saveApiKeysSettings(eq(testUser), eq(apiKeysReq));
+        verify(apiKeySettingService).saveApiKeysSettings(eq(testUser), eq(balance), eq(apiKeysReq));
 
         assertThat(result).isNotNull();
         assertThat(result.getBalanceName()).isEqualTo(BALANCE_NAME);

--- a/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/services/exchangers/balances/LocalBalanceServiceTest.java
+++ b/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/services/exchangers/balances/LocalBalanceServiceTest.java
@@ -5,6 +5,7 @@ import com.walletsphere.wsmonolith.model.exchanger.Balance;
 import com.walletsphere.wsmonolith.repositories.BalanceRepository;
 import com.walletsphere.wsmonolith.services.UserService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorServiceFactory;
+import com.walletsphere.wsmonolith.services.exchangers.apikeys.ApiKeySettingService;
 import com.walletsphere.wsmonolith.services.exchangers.balances.cache.BalanceCacheHandler;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import org.junit.jupiter.api.BeforeEach;
@@ -31,12 +32,15 @@ class LocalBalanceServiceTest {
     @Mock
     private BalanceCacheHandler balanceCacheHandler;
 
+    @Mock
+    private ApiKeySettingService apiKeySettingService;
+
     private LocalBalanceService localBalanceService;
 
     @BeforeEach
     void setUp() {
         localBalanceService = new LocalBalanceService(balanceRepository, userService, List.of(exchangerServiceFactory),
-                balanceCacheHandler);
+                balanceCacheHandler, apiKeySettingService);
     }
 
     @Test

--- a/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/services/exchangers/balances/RemoteBalanceServiceTest.java
+++ b/service/monolith-part/src/test/java/com/walletsphere/wsmonolith/services/exchangers/balances/RemoteBalanceServiceTest.java
@@ -8,6 +8,7 @@ import com.walletsphere.wsmonolith.repositories.BalanceRepository;
 import com.walletsphere.wsmonolith.services.UserService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorService;
 import com.walletsphere.wsmonolith.services.exchangers.ExchangerConnectorServiceFactory;
+import com.walletsphere.wsmonolith.services.exchangers.apikeys.ApiKeySettingService;
 import com.walletsphere.wsmonolith.services.exchangers.balances.cache.BalanceCacheHandler;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import org.junit.jupiter.api.BeforeEach;
@@ -37,6 +38,8 @@ class RemoteBalanceServiceTest {
     private ExchangerConnectorService exchangerConnectorService;
     @Mock
     private BalanceCacheHandler balanceCacheHandler;
+    @Mock
+    private ApiKeySettingService apiKeySettingService;
 
     private RemoteBalanceService remoteBalanceService;
 
@@ -47,7 +50,7 @@ class RemoteBalanceServiceTest {
         when(exchangerServiceFactory.getExchangerCode()).thenReturn(ExchangerCode.WHITE_BIT);
         testUser = User.builder().id(USER_ID).build();
         remoteBalanceService = new RemoteBalanceService(balanceRepository, List.of(exchangerServiceFactory),
-                userService , balanceCacheHandler);
+                userService , balanceCacheHandler, apiKeySettingService);
     }
 
     @Test


### PR DESCRIPTION
firstly moved all apiKeys related logic to ApiKeysService to avoid mixed up code
secondly fixed the way we entwine apiKeys and balance entities so each of them would have other's id as foreign key
it also fixed the issue with delete functionality, as we have cascade type REMOVE for ApiKeySetting in Balance entity